### PR TITLE
Add inplace cov! computation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -35,6 +35,7 @@ julia = "1.9"
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 CpuId = "adafc99b-e345-5852-983c-f28acb93d879"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 HCubature = "19dc6840-f33b-545b-b366-655c7e3ffd49"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 ReTestItems = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
@@ -42,4 +43,4 @@ StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "CpuId", "Test", "ReTestItems", "LinearAlgebra", "StableRNGs", "HCubature"]
+test = ["Aqua", "CpuId", "JET", "Test", "ReTestItems", "LinearAlgebra", "StableRNGs", "HCubature"]

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -87,6 +87,7 @@ BayesBase.clamplog
 BayesBase.mvtrigamma
 BayesBase.dtanh
 BayesBase.probvec
+BayesBase.mcov!
 BayesBase.mean_std
 BayesBase.mean_var
 BayesBase.mean_cov

--- a/src/BayesBase.jl
+++ b/src/BayesBase.jl
@@ -1,6 +1,6 @@
 module BayesBase
 
-using TinyHugeNumbers
+using TinyHugeNumbers, LoopVectorization
 using StatsAPI, StatsBase, DomainSets, Statistics, Distributions, Random
 
 import StatsAPI: params

--- a/test/statsfuns_tests.jl
+++ b/test/statsfuns_tests.jl
@@ -26,10 +26,10 @@ end
     end
 end
 
-@testitem "dtanh" begin 
+@testitem "dtanh" begin
     for T in (Float32, Float64, BigFloat)
         foreach(rand(T, 10)) do number
-            @test dtanh(number) ≈ 1 - tanh(number) ^ 2
+            @test dtanh(number) ≈ 1 - tanh(number)^2
         end
     end
 end
@@ -87,6 +87,32 @@ end
 
         @test float(convert(CountingReal, r)) ≈ zero(T)
         @test float(convert(CountingReal{Float64}, r)) ≈ zero(Float64)
+    end
+end
 
+@testitem "mcov!" begin
+    using StatsFuns, BayesBase, JET
+    import BayesBase: mcov!
+
+    for n in 2:5:20, j in 3:5:20
+        X = rand(j, n)
+        Y = rand(j, n)
+        Z = rand(n, n)
+
+        @inferred(mcov!(Z, X, Y))
+
+        @test all(Z .≈ cov(X, Y))
+
+        tmp1 = zeros(eltype(Z), size(X, 2))
+        tmp2 = zeros(eltype(Z), size(Y, 2))
+        tmp3 = similar(X)
+        tmp4 = similar(Y)
+
+        @inferred(mcov!(Z, X, Y; tmp1=tmp1, tmp2=tmp2, tmp3=tmp3, tmp4=tmp4))
+
+        @test all(Z .≈ cov(X, Y))
+
+        @report_opt mcov!(Z, X, Y; tmp1=tmp1, tmp2=tmp2, tmp3=tmp3, tmp4=tmp4)
+        @test @allocated(mcov!(Z, X, Y; tmp1=tmp1, tmp2=tmp2, tmp3=tmp3, tmp4=tmp4)) === 0
     end
 end


### PR DESCRIPTION
This PR adds a simple function `mcov!` that does exactly the same as `cov`, but does not allocate.