### PR TITLE
ProductOf should use `insupport`

### DIFF
--- a/src/prod.jl
+++ b/src/prod.jl
@@ -182,10 +182,14 @@ function BayesBase.support(product::ProductOf)
     return fuse_supports(support(getleft(product)), support(getright(product)))
 end
 
+function BayesBase.insupport(product::ProductOf, x)
+    return insupport(getleft(product), x) && insupport(getright(product), x)
+end
+
 BayesBase.pdf(product::ProductOf, x) = exp(logpdf(product, x))
 
 function BayesBase.logpdf(product::ProductOf, x)
-    @assert x ∈ support(product) "The `$(x)` does not belong to the support of the product `$(product)`"
+    @assert insupport(product, x) lazy"The `$(x)` does not belong to the support of the product `$(product)`"
     return logpdf(getleft(product), x) + logpdf(getright(product), x)
 end
 
@@ -332,6 +336,7 @@ function Base.push!(product::LinearizedProductOf{F}, item::F) where {F}
 end
 
 BayesBase.support(dist::LinearizedProductOf) = support(first(dist.vector))
+BayesBase.insupport(dist::LinearizedProductOf, x) = insupport(first(dist.vector), x)
 
 Base.length(product::LinearizedProductOf) = product.length
 Base.eltype(product::LinearizedProductOf) = eltype(first(product.vector))
@@ -352,7 +357,7 @@ function Base.show(io::IO, product::LinearizedProductOf{F}) where {F}
 end
 
 function BayesBase.logpdf(product::LinearizedProductOf, x)
-    @assert x ∈ support(product) "The `$(x)` does not belong to the support of the product `$(product)`"
+    @assert insupport(product, x) "The `$(x)` does not belong to the support of the product `$(product)`"
     return mapreduce(
         (d) -> logpdf(d, x),
         +,

--- a/test/densities/function_tests.jl
+++ b/test/densities/function_tests.jl
@@ -191,8 +191,8 @@ end
     d5 = ContinuousUnivariateLogPdf(FullSpace(), (x) -> 2.0 * -x^2)
     d6 = ContinuousUnivariateLogPdf(HalfLine(), (x) -> 2.0 * -x^2)
 
-    @test_throws AssertionError logpdf(prod(GenericProd(), d5, d6), 1.0) # domains are different
-    @test_throws AssertionError logpdf(prod(GenericProd(), d5, d6), -1.0) # domains are different
+    @test logpdf(prod(GenericProd(), d5, d6), 1.0) ≈ -4.0
+    @test_throws AssertionError logpdf(prod(GenericProd(), d5, d6), -1.0) # supports are different
 end
 
 @testitem "ContinuousUnivariateLogPdf: vectorised-prod" begin

--- a/test/prod_tests.jl
+++ b/test/prod_tests.jl
@@ -293,3 +293,39 @@ end
         PreserveTypeRightProd(), PreserveTypeLeftProd()
     )
 end
+
+@testitem "`ProductOf` should support distributions that do not have explicitly defined `support`" begin
+    
+    struct SomeComplexDistribution end
+
+    BayesBase.support(::SomeComplexDistribution) = error("not defined")
+    BayesBase.insupport(::SomeComplexDistribution, x) = x > 0
+    BayesBase.logpdf(::SomeComplexDistribution, x) = x
+
+    prod = ProductOf(SomeComplexDistribution(), SomeComplexDistribution())
+
+    @test_throws "not defined" support(prod)
+    @test insupport(prod, 1)
+    @test !insupport(prod, -1)
+    @test logpdf(prod, 1) === 2
+    @test logpdf(prod, 2) === 4
+
+end
+
+@testitem "`LinearizedProductOf` should support distributions that do not have explicitly defined `support`" begin
+    
+    struct SomeComplexDistribution end
+
+    BayesBase.support(::SomeComplexDistribution) = error("not defined")
+    BayesBase.insupport(::SomeComplexDistribution, x) = x > 0
+    BayesBase.logpdf(::SomeComplexDistribution, x) = x
+
+    prod = LinearizedProductOf([SomeComplexDistribution(), SomeComplexDistribution()], 2)
+
+    @test_throws "not defined" support(prod)
+    @test insupport(prod, 1)
+    @test !insupport(prod, -1)
+    @test logpdf(prod, 1) === 2
+    @test logpdf(prod, 2) === 4
+
+end


### PR DESCRIPTION
This pull request refines the implementation of `ProductOf` by transitioning from utilizing `support` to `insupport` whenever feasible. The reasoning behind this adjustment is that not all distributions define support as an object, for various reasons. In some cases, it might be inefficient to create it each time, opting instead to verify if an element is within the support range. Additionally, certain technical constraints, such as infinite supports, may render the implementation of `support` unfeasible.