### PR TITLE
Resolve ambiguity in the prod method for ProductOf

### DIFF
--- a/src/prod.jl
+++ b/src/prod.jl
@@ -388,12 +388,6 @@ function Base.prod(
 end
 
 function Base.prod(
-    ::GenericProd, ::UnspecifiedProd, ::UnspecifiedProd, left::ProductOf{F,F}, right::F
-) where {F}
-    return LinearizedProductOf(F[getleft(left), getright(left), right], 3)
-end
-
-function Base.prod(
     ::GenericProd, ::UnspecifiedProd, ::UnspecifiedProd, left::ProductOf{L,R}, right::R
 ) where {L,R}
     return ProductOf(getleft(left), LinearizedProductOf(R[getright(left), right], 2))

--- a/src/prod.jl
+++ b/src/prod.jl
@@ -418,6 +418,18 @@ function Base.prod(
 end
 
 function Base.prod(
+    ::GenericProd, ::UnspecifiedProd, ::UnspecifiedProd, left::T, right::ProductOf{T,T}
+) where {T}
+    return LinearizedProductOf(T[left, getleft(right), getright(right)], 3)
+end
+
+function Base.prod(
+    ::GenericProd, ::UnspecifiedProd, ::UnspecifiedProd, left::ProductOf{T,T}, right::T
+) where {T}
+    return LinearizedProductOf(T[getleft(left), getright(left), right], 3)
+end
+
+function Base.prod(
     ::GenericProd,
     ::UnspecifiedProd,
     ::UnspecifiedProd,

--- a/test/prod_tests.jl
+++ b/test/prod_tests.jl
@@ -295,7 +295,6 @@ end
 end
 
 @testitem "`ProductOf` should support distributions that do not have explicitly defined `support`" begin
-    
     struct SomeComplexDistribution end
 
     BayesBase.support(::SomeComplexDistribution) = error("not defined")
@@ -309,11 +308,9 @@ end
     @test !insupport(prod, -1)
     @test logpdf(prod, 1) === 2
     @test logpdf(prod, 2) === 4
-
 end
 
 @testitem "`LinearizedProductOf` should support distributions that do not have explicitly defined `support`" begin
-    
     struct SomeComplexDistribution end
 
     BayesBase.support(::SomeComplexDistribution) = error("not defined")
@@ -327,5 +324,34 @@ end
     @test !insupport(prod, -1)
     @test logpdf(prod, 1) === 2
     @test logpdf(prod, 2) === 4
+end
 
+@testitem "There should be no ambiguity in `prod` for `ProductOf`" begin
+    struct SomeArbitraryDistribution end
+
+    @test prod(
+        GenericProd(),
+        SomeArbitraryDistribution(),
+        ProductOf(SomeArbitraryDistribution(), SomeArbitraryDistribution()),
+    ) == LinearizedProductOf(
+        [
+            SomeArbitraryDistribution(),
+            SomeArbitraryDistribution(),
+            SomeArbitraryDistribution(),
+        ],
+        3,
+    )
+
+    @test prod(
+        GenericProd(),
+        ProductOf(SomeArbitraryDistribution(), SomeArbitraryDistribution()),
+        SomeArbitraryDistribution(),
+    ) == LinearizedProductOf(
+        [
+            SomeArbitraryDistribution(),
+            SomeArbitraryDistribution(),
+            SomeArbitraryDistribution(),
+        ],
+        3,
+    )
 end


### PR DESCRIPTION
This PR fixes a small issue with method ambiguity with certain parameters configuration for the `prod` function.