### PR TITLE
Generalize pointmasses for abstractarray

### DIFF
--- a/src/densities/pointmass.jl
+++ b/src/densities/pointmass.jl
@@ -119,13 +119,13 @@ function BayesBase.probvec(distribution::PointMass{V}) where {T<:Real,V<:Abstrac
 end
 
 function BayesBase.cov(distribution::PointMass{M}) where {T<:Real,N,M<:AbstractArray{T,N}}
-    return error("cov(::PointMass{ <: AbstractMatrix }) is not defined")
+    return error("cov(::PointMass{ <: $M }) is not defined")
 end
 
 function BayesBase.probvec(
     distribution::PointMass{M}
 ) where {T<:Real,N,M<:AbstractArray{T,N}}
-    return error("probvec(::PointMass{ <: AbstractMatrix }) is not defined")
+    return error("probvec(::PointMass{ <: $M }) is not defined")
 end
 
 function Base.precision(distribution::PointMass{V}) where {T<:Real,V<:AbstractArray{T}}


### PR DESCRIPTION
Basically what the PR title says. I'm not sure about `Base.ndims` for vectors now. I implemented it separately now for backwards compatibility but it seems that it is only used in `std` and `var` and can therefore also just work with the generic implementation.