### PR TITLE
feat: implement getindex method for ArrowheadMatrix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BayesBase"
 uuid = "b4ee3484-f114-42fe-b91c-797d54a0c67e"
 authors = ["Bagaev Dmitry <d.v.bagaev@tue.nl> and contributors"]
-version = "1.4.0"
+version = "1.5.0"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"


### PR DESCRIPTION
1. ArrowheadMatrix:
   - Added `getindex` with one-time performance warning
   - Enhanced error handling for invalid indices
   - Implemented `≈` (isapprox) operator
   - Improved matrix multiplication consistency

2. InvArrowheadMatrix:
   - Implemented efficient `dot(x, A, y)` for real vectors
   - Utilized `linsolve!` to avoid explicit inverse computation

3. General Improvements:
   - Ensured error consistency with dense matrices
   - Expanded test suite for new features and edge cases
   - Optimized performance with in-place operations

These changes need to these PR's tests to pass https://github.com/ReactiveBayes/ExponentialFamily.jl/pull/206